### PR TITLE
Update anoma

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  ANOMA_VERSION: 7fdd77377317ff0e29676a403b384cb1f2dc4729
+  ANOMA_VERSION: 8cc25d3fd64ad20623c8135eaa0a6d2096016549
 
 jobs:
   build-test:

--- a/HelloWorld/web-app/README.md
+++ b/HelloWorld/web-app/README.md
@@ -46,10 +46,11 @@ npm install
 Run the following in this directory.
 
 ``` sh
-npm install
-make build  # build the Anoma application
+npm install # only for the first time
 export ANOMA_PATH=<path to Anoma node clone>
-make start   # start the Anoma node / client and the envoy proxy
+make anoma-start # start Anoma
+make build  # build the Anoma application
+make proxy-start   # start the envoy proxy
 npm run serve  # serve the webapp at http://localhost:9000
 ```
 

--- a/HelloWorld/web-app/README.md
+++ b/HelloWorld/web-app/README.md
@@ -4,7 +4,7 @@
 
 1. [Anoma node](https://github.com/anoma/anoma)
 
-This should be cloned at commit `7fdd77377317ff0e29676a403b384cb1f2dc4729` and
+This should be cloned at commit `8cc25d3fd64ad20623c8135eaa0a6d2096016549` and
 the [setup instrucions](https://github.com/anoma/anoma?tab=readme-ov-file#compilation-from-sources) should be followed.
 
 2. [Juvix compiler nightly](https://github.com/anoma/juvix-nightly-builds/releases/tag/nightly-2025-01-22-0.6.9-88de274)

--- a/HelloWorld/web-app/makefile
+++ b/HelloWorld/web-app/makefile
@@ -35,12 +35,6 @@ clean:
 	rm -rf $(dst)
 	rm -rf $(anoma-build-dir)
 
-.PHONY: start
-start: anoma-start proxy-start
-
-.PHONY: stop
-stop: anoma-stop proxy-stop
-
 .PHONY: anoma-start
 anoma-start:
 	rm -f $(anoma-config)

--- a/anoma-client/README.md
+++ b/anoma-client/README.md
@@ -5,9 +5,9 @@ gRPC calls to an Anoma client.
 
 ### Anoma compatible version
 
-The protobuf files in [`protobuf`](./protobuf) are obtained from [`anoma/anoma:apps/anoma_protobuf/priv/protobuf`](https://github.com/anoma/anoma/tree/7fdd77377317ff0e29676a403b384cb1f2dc4729/apps/anoma_protobuf/priv/protobuf).
+The protobuf files in [`protobuf`](./protobuf) are obtained from [`anoma/anoma:apps/anoma_protobuf/priv/protobuf`](https://github.com/anoma/anoma/tree/8cc25d3fd64ad20623c8135eaa0a6d2096016549/apps/anoma_protobuf/priv/protobuf).
 
-The client has been tested with `anoma/anoma:7fdd77377317ff0e29676a403b384cb1f2dc4729`
+The client has been tested with `anoma/anoma:8cc25d3fd64ad20623c8135eaa0a6d2096016549`
 
 ### Generating new gRPC-web bindings
 


### PR DESCRIPTION
- This pr updates the Anoma ref to 8cc25d3fd64ad20623c8135eaa0a6d2096016549 in order to be in sync with https://github.com/anoma/juvix/pull/3277/files
- I've also updated the makefile and the readme for the HelloWorld web app. The changes were needed because the anoma node needs to be running for `make build` to succeed.