### PR TITLE
Update Anoma ref and Juvix nightly for HelloWorld web-app

### DIFF
--- a/HelloWorld/web-app/README.md
+++ b/HelloWorld/web-app/README.md
@@ -4,10 +4,15 @@
 
 1. [Anoma node](https://github.com/anoma/anoma)
 
-This should be cloned at commit `5c7bd8121206fbebdc3f7f75fdea3697f09566a0` and
-the [setup instrucions](https://github.com/anoma/anoma?tab=readme-ov-file#compilation-from-sources) should be followed.
+Clone the Anoma node repository and checkout at commit ref `96b89b5ab11dd57e14349ff56555884491bb0d3d`:
 
-2. [Juvix compiler nightly](https://github.com/anoma/juvix-nightly-builds/releases/tag/nightly-2025-01-30-0.6.9-27cc711)
+``` sh
+git checkout 96b89b5ab11dd57e14349ff56555884491bb0d3d
+```
+
+Follow the the [setup instrucions](https://github.com/anoma/anoma?tab=readme-ov-file#compilation-from-sources) for Anoma.
+
+2. [Juvix compiler nightly](https://github.com/anoma/juvix-nightly-builds/releases/tag/nightly-2025-02-13-0.6.9-8b06157)
 
 Download the nightly binary for your platform at the link and put it on your system PATH.
 


### PR DESCRIPTION
This PR updates the Anoma node git reference and Juvix nightly link for the HelloWorld web-app to match the versions we'll document for anoma-apps 0.2.0.