### PR TITLE
Run apps test in parallel

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -112,21 +112,15 @@ jobs:
         run: |
           echo "ANOMA_PATH=${{ github.workspace }}/anoma" >> $GITHUB_ENV
 
-      - name: HelloWorld Run tests
-        run: cd HelloWorld/tests && ./all-tests.sh
+      - name: Run tests
+        run: |
+          ./run-tests.sh
 
-      - name: SimpleHelloWorld Run tests
-        run: cd SimpleHelloWorld/tests && ./all-tests.sh
-        
-      - name: Run Simple Counter tests
-        run: cd Counters/Counter/Simple/tests && ./all-tests.sh
-
-      - name: Run Unique Counter tests
-        run: cd Counters/Counter/Unique/tests && ./all-tests.sh
-
-      - name: Run Kudos tests
-        shell: bash
-        run: cd Kudos/tests && ./all-tests.sh
+      - name: Upload test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-logs
+          path: "**/all-tests.log"
 
       - name: Build HelloWorld app
         working-directory: ${{ github.workspace }}/HelloWorld/web-app

--- a/Counters/Counter/Simple/makefile
+++ b/Counters/Counter/Simple/makefile
@@ -13,6 +13,12 @@
 ANOMA_PATH ?= $(error set the ANOMA_PATH variable to a path to an anoma clone)
 ANOMA_DEBUG ?=
 
+ifneq ($(XDG_CONFIG_HOME),)
+    juvix-cmd = XDG_CONFIG_HOME=$(XDG_CONFIG_HOME) juvix
+else
+    juvix-cmd = juvix
+endif
+
 base-path = .
 
 initialize = Initialize
@@ -60,7 +66,7 @@ anoma-stop:
 ifdef ANOMA_DEBUG
 	@echo "ANOMA_DEBUG is incompatible with anoma-stop" && false
 else
-	juvix dev anoma stop
+	$(juvix-cmd) dev anoma stop
 endif
 
 .PHONY: anoma-start
@@ -70,7 +76,7 @@ ifdef ANOMA_DEBUG
 	cd $(ANOMA_PATH) && \
 		mix run --no-halt $(root)/../../start-config.exs
 else
-	juvix dev anoma start --force --anoma-dir $(ANOMA_PATH)
+	$(juvix-cmd) dev anoma start --force --anoma-dir $(ANOMA_PATH)
 endif
 
 .PHONY: get-latest-root
@@ -83,11 +89,11 @@ get-unspent-resources: $(unspent-resources)
 
 .PHONY: counter-initialize
 counter-initialize: $(initialize-proved) $(config)
-	juvix dev anoma -c $(config) add-transaction $(initialize-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(initialize-proved)
 
 .PHONY: counter-increment
 counter-increment: $(increment-proved) $(config)
-	juvix dev anoma -c $(config) add-transaction $(increment-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(increment-proved)
 
 .PHONY: counter-get
 counter-get: $(get-count-result)
@@ -121,36 +127,36 @@ $(config): $(anoma-build)
 ifdef ANOMA_DEBUG
 	cp $(ANOMA_PATH)/config.yaml $(config)
 else
-	juvix dev anoma print-config > $(config)
+	$(juvix-cmd) dev anoma print-config > $(config)
 endif
 
 $(initialize-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(initialize-juvix) -o $(initialize-nockma)
+	$(juvix-cmd) compile anoma $(initialize-juvix) -o $(initialize-nockma)
 
 $(initialize-proved): $(counter-logic-proved) $(initialize-nockma) $(config)
-	juvix dev anoma -c $(config) prove $(initialize-nockma) -o $(initialize-proved) --arg "bytes:$(counter-logic-proved)"
+	$(juvix-cmd) dev anoma -c $(config) prove $(initialize-nockma) -o $(initialize-proved) --arg "bytes:$(counter-logic-proved)"
 
 $(increment-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(increment-juvix) -o $(increment-nockma)
+	$(juvix-cmd) compile anoma $(increment-juvix) -o $(increment-nockma)
 
 $(increment-proved): $(increment-nockma) $(unspent-resources) $(get-latest-root) $(config) $(counter-logic-proved)
-	juvix dev anoma -c $(config) prove $(increment-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(increment-nockma) \
 	-o $(increment-proved) \
 	--arg "bytes:$(counter-logic-proved)" \
 	--arg "base64:$(unspent-resources)" \
 	--arg "base64-unjammed:$(get-latest-root)"
 
 $(get-count-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(get-count-juvix) -o $(get-count-nockma)
+	$(juvix-cmd) compile anoma $(get-count-juvix) -o $(get-count-nockma)
 
 $(get-count-proved): $(unspent-resources) $(get-count-nockma) $(config)
-	juvix dev anoma -c $(config) prove $(get-count-nockma) -o $(get-count-proved) --arg "base64:$(unspent-resources)"
+	$(juvix-cmd) dev anoma -c $(config) prove $(get-count-nockma) -o $(get-count-proved) --arg "base64:$(unspent-resources)"
 
 $(get-count-result): $(get-count-proved)
-	juvix dev nockma encode --from bytes --to text < $(get-count-proved) > $(get-count-result)
+	$(juvix-cmd) dev nockma encode --from bytes --to text < $(get-count-proved) > $(get-count-result)
 
 $(counter-logic-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(counter-logic-juvix) -o $(counter-logic-nockma)
+	$(juvix-cmd) compile anoma $(counter-logic-juvix) -o $(counter-logic-nockma)
 
 $(counter-logic-proved): $(counter-logic-nockma) $(config)
-	juvix dev anoma -c $(config) prove $(counter-logic-nockma) -o $(counter-logic-proved)
+	$(juvix-cmd) dev anoma -c $(config) prove $(counter-logic-nockma) -o $(counter-logic-proved)

--- a/Counters/Counter/Unique/makefile
+++ b/Counters/Counter/Unique/makefile
@@ -18,6 +18,12 @@
 ANOMA_PATH ?= $(error set the ANOMA_PATH variable to a path to an anoma clone)
 ANOMA_DEBUG ?=
 
+ifneq ($(XDG_CONFIG_HOME),)
+    juvix-cmd = XDG_CONFIG_HOME=$(XDG_CONFIG_HOME) juvix
+else
+    juvix-cmd = juvix
+endif
+
 # Change this to create a new counter identity
 counter_id ?= 0
 
@@ -93,15 +99,15 @@ clean:
 
 .PHONY: create-consumable-resource
 create-consumable-resource: $(config) $(consumable-transaction-proved)
-	juvix dev anoma -c $(config) add-transaction $(consumable-transaction-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(consumable-transaction-proved)
 
 .PHONY: counter-initialize
 counter-initialize: $(initialize-proved) $(config)
-	juvix dev anoma -c $(config) add-transaction $(initialize-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(initialize-proved)
 
 .PHONY: counter-increment
 counter-increment: $(increment-proved) $(config)
-	juvix dev anoma -c $(config) add-transaction $(increment-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(increment-proved)
 
 .PHONY: counter-get
 counter-get: $(get-count-result)
@@ -113,7 +119,7 @@ anoma-stop:
 ifdef ANOMA_DEBUG
 	@echo "ANOMA_DEBUG is incompatible with anoma-stop" && false
 else
-	juvix dev anoma stop
+	$(juvix-cmd) dev anoma stop
 endif
 
 .PHONY: anoma-start
@@ -123,14 +129,14 @@ ifdef ANOMA_DEBUG
 	cd $(ANOMA_PATH) && \
 		mix run --no-halt $(root)/../../start-config.exs
 else
-	juvix dev anoma start --force --anoma-dir $(ANOMA_PATH)
+	$(juvix-cmd) dev anoma start --force --anoma-dir $(ANOMA_PATH)
 endif
 
 $(config): $(anoma-build)
 ifdef ANOMA_DEBUG
 	cp $(anoma-config) $(config)
 else
-	juvix dev anoma print-config > $(config)
+	$(juvix-cmd) dev anoma print-config > $(config)
 endif
 
 $(host): $(config)
@@ -169,23 +175,23 @@ $(current-counter): $(anoma-build) $(host) $(port) $(current-counter-request)
 	> $(current-counter)
 
 $(consumable-nockma): $(anoma-build) $(consumable-juvix)
-	juvix compile anoma $(consumable-juvix) -o $(consumable-nockma)
+	$(juvix-cmd) compile anoma $(consumable-juvix) -o $(consumable-nockma)
 
 $(consumable-proved): $(config) $(random-32bytes) $(consumable-nockma)
-	juvix dev anoma -c $(config) prove $(consumable-nockma) -o $(consumable-proved) --arg "bytes-unjammed:$(random-32bytes)"
+	$(juvix-cmd) dev anoma -c $(config) prove $(consumable-nockma) -o $(consumable-proved) --arg "bytes-unjammed:$(random-32bytes)"
 
 $(consumable-transaction-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(consumable-transaction-juvix) -o $(consumable-transaction-nockma)
+	$(juvix-cmd) compile anoma $(consumable-transaction-juvix) -o $(consumable-transaction-nockma)
 
 $(consumable-transaction-proved): $(config) $(consumable-transaction-nockma) $(consumable-proved)
-	juvix dev anoma -c $(config) prove $(consumable-transaction-nockma) -o $(consumable-transaction-proved) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(consumable-transaction-nockma) -o $(consumable-transaction-proved) \
 	--arg "bytes:$(consumable-proved)"
 
 $(logic-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(logic-juvix) -o $(logic-nockma)
+	$(juvix-cmd) compile anoma $(logic-juvix) -o $(logic-nockma)
 
 $(logic-proved): $(logic-nockma) $(config)
-	juvix dev anoma -c $(config) prove $(logic-nockma) -o $(logic-proved)
+	$(juvix-cmd) dev anoma -c $(config) prove $(logic-nockma) -o $(logic-proved)
 
 .PHONY: $(get-latest-root) $(host) $(port)
 $(get-latest-root): $(anoma-build) $(host) $(port)
@@ -194,42 +200,42 @@ $(get-latest-root): $(anoma-build) $(host) $(port)
 	> $(get-latest-root)
 
 $(initialize-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(initialize-juvix) -o $(initialize-nockma)
+	$(juvix-cmd) compile anoma $(initialize-juvix) -o $(initialize-nockma)
 
 $(initialize-proved): $(initialize-nockma) $(logic-proved) $(random-32bytes-initialize) $(consumable-proved) $(get-latest-root) $(config)
-	juvix dev anoma -c $(config) prove $(initialize-nockma) -o $(initialize-proved) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(initialize-nockma) -o $(initialize-proved) \
 	--arg "bytes-unjammed:$(random-32bytes-initialize)" \
 	--arg "bytes:$(consumable-proved)" \
     --arg "bytes:$(logic-proved)" \
 	--arg "base64-unjammed:$(get-latest-root)"
 
 $(increment-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(increment-juvix) -o $(increment-nockma)
+	$(juvix-cmd) compile anoma $(increment-juvix) -o $(increment-nockma)
 
 $(increment-proved): $(increment-nockma) $(logic-proved) $(random-32bytes-increment) $(current-counter) $(get-latest-root) $(config)
-	juvix dev anoma -c $(config) prove $(increment-nockma) -o $(increment-proved) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(increment-nockma) -o $(increment-proved) \
 	--arg "bytes-unjammed:$(random-32bytes-increment)" \
 	--arg "base64:$(current-counter)" \
     --arg "bytes:$(logic-proved)" \
 	--arg "base64-unjammed:$(get-latest-root)"
 
 $(counter-kind-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(counter-kind-juvix) -o $(counter-kind-nockma)
+	$(juvix-cmd) compile anoma $(counter-kind-juvix) -o $(counter-kind-nockma)
 
 .PHONY: $(counter-kind-proved)
 $(counter-kind-proved): $(counter-kind-nockma) $(logic-proved) $(consumable-proved) $(config)
-	juvix dev anoma -c $(config) prove $(counter-kind-nockma) -o $(counter-kind-proved) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(counter-kind-nockma) -o $(counter-kind-proved) \
 	--arg "bytes:$(consumable-proved)" \
     --arg "bytes:$(logic-proved)"
 
 $(counter-kind-proved-cued-b64): $(counter-kind-proved)
-	juvix dev nockma encode --cue --from bytes --to base64 < $(counter-kind-proved) > $(counter-kind-proved-cued-b64)
+	$(juvix-cmd) dev nockma encode --cue --from bytes --to base64 < $(counter-kind-proved) > $(counter-kind-proved-cued-b64)
 
 $(get-count-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(get-count-juvix) -o $(get-count-nockma)
+	$(juvix-cmd) compile anoma $(get-count-juvix) -o $(get-count-nockma)
 
 $(get-count-proved): $(current-counter) $(get-count-nockma) $(config)
-	juvix dev anoma -c $(config) prove $(get-count-nockma) -o $(get-count-proved) --arg "base64:$(current-counter)"
+	$(juvix-cmd) dev anoma -c $(config) prove $(get-count-nockma) -o $(get-count-proved) --arg "base64:$(current-counter)"
 
 $(get-count-result): $(get-count-proved)
-	juvix dev nockma encode --from bytes --to text < $(get-count-proved) > $(get-count-result)
+	$(juvix-cmd) dev nockma encode --from bytes --to text < $(get-count-proved) > $(get-count-result)

--- a/HelloWorld/makefile
+++ b/HelloWorld/makefile
@@ -12,6 +12,13 @@
 # ...
 # 5. make anoma-stop # stop the Anoma node when you've finished
 ANOMA_PATH ?= $(error set the ANOMA_PATH variable to a path to an anoma clone)
+
+ifneq ($(XDG_CONFIG_HOME),)
+    juvix-cmd = XDG_CONFIG_HOME=$(XDG_CONFIG_HOME) juvix
+else
+    juvix-cmd = juvix
+endif
+
 base-path = .
 base = HelloWorld
 get-message = GetMessage
@@ -69,7 +76,7 @@ ifdef ANOMA_DEBUG
 	cd $(ANOMA_PATH) && \
 		mix run --no-halt $(root)/../../start-config.exs
 else
-	juvix dev anoma start --force --anoma-dir $(ANOMA_PATH)
+	$(juvix-cmd) dev anoma start --force --anoma-dir $(ANOMA_PATH)
 endif
 
 .PHONY: anoma-stop
@@ -77,7 +84,7 @@ anoma-stop:
 ifdef ANOMA_DEBUG
 	@echo "ANOMA_DEBUG is incompatible with anoma-stop" && false
 else
-	juvix dev anoma stop
+	$(juvix-cmd) dev anoma stop
 endif
 
 .PHONY: $(message-file)
@@ -86,7 +93,7 @@ $(message-file): $(anoma-build)
 	> $(message-file)
 
 $(config): $(anoma-build)
-	@juvix dev anoma print-config > $(config)
+	@$(juvix-cmd) dev anoma print-config > $(config)
 
 .PHONY: compile-add-message
 compile-add-message: $(nockma)
@@ -102,7 +109,7 @@ compute-kind: $(kind-proved-cued)
 
 .PHONY: add-transaction
 add-transaction: $(proved) $(config)
-	@juvix dev anoma -c $(config) add-transaction $(proved)
+	@$(juvix-cmd) dev anoma -c $(config) add-transaction $(proved)
 
 .PHONY: get-last-message
 get-last-message: $(last-message-txt)
@@ -111,35 +118,35 @@ get-last-message: $(last-message-txt)
 .PHONY: $(last-message-txt)
 $(last-message-txt): $(get-message-nockma) $(config) $(unspent-resources)
 	@tail -n 1 $(unspent-resources) > $(temp-file)
-	@juvix dev anoma -c $(config) prove $(get-message-nockma) -o $(get-message-proved) --arg 'base64:$(temp-file)'
-	@juvix dev nockma encode --cue --from bytes --to bytes < anoma-build/GetMessage.proved.nockma > $(last-message-txt)
+	@$(juvix-cmd) dev anoma -c $(config) prove $(get-message-nockma) -o $(get-message-proved) --arg 'base64:$(temp-file)'
+	@$(juvix-cmd) dev nockma encode --cue --from bytes --to bytes < anoma-build/GetMessage.proved.nockma > $(last-message-txt)
 
 .PHONY: get-all-messages
 get-all-messages: $(get-message-nockma) $(config) $(unspent-resources)
 	@while IFS= read -r line; do \
 		echo "$$line" > $(temp-file); \
-		juvix dev anoma -c $(config) prove $(get-message-nockma) -o $(get-message-proved) --arg 'base64:$(temp-file)'; \
-		juvix dev nockma encode --cue --from bytes --to bytes < anoma-build/GetMessage.proved.nockma > $(last-message-txt); \
+		$(juvix-cmd) dev anoma -c $(config) prove $(get-message-nockma) -o $(get-message-proved) --arg 'base64:$(temp-file)'; \
+		$(juvix-cmd) dev nockma encode --cue --from bytes --to bytes < anoma-build/GetMessage.proved.nockma > $(last-message-txt); \
 		cat $(last-message-txt); \
 	done < $(unspent-resources)
 
 $(nockma): $(juvix) $(anoma-build)
-	@juvix compile anoma $(juvix) -o $(nockma)
+	$(juvix-cmd) compile anoma $(juvix) -o $(nockma)
 
 $(proved): $(nockma) $(config) $(message-file) $(logic-proved)
-	juvix dev anoma -c $(config) prove $(nockma) -o $(proved) --arg 'bytes:$(logic-proved)' --arg 'bytes-unjammed:$(message-file)'
+	$(juvix-cmd) dev anoma -c $(config) prove $(nockma) -o $(proved) --arg 'bytes:$(logic-proved)' --arg 'bytes-unjammed:$(message-file)'
 
 $(kind-nockma): $(kind-juvix) $(anoma-build)
-	@juvix compile anoma $(kind-juvix) -o $(kind-nockma)
+	@$(juvix-cmd) compile anoma $(kind-juvix) -o $(kind-nockma)
 
 $(kind-proved): $(kind-nockma) $(config) $(logic-proved)
-	@juvix dev anoma -c $(config) prove $(kind-nockma) -o $(kind-proved) --arg 'bytes:$(logic-proved)'
+	@$(juvix-cmd) dev anoma -c $(config) prove $(kind-nockma) -o $(kind-proved) --arg 'bytes:$(logic-proved)'
 
 $(kind-proved-cued): $(kind-proved)
-	@juvix dev nockma encode --cue --from bytes --to bytes < $(kind-proved) > $(kind-proved-cued)
+	@$(juvix-cmd) dev nockma encode --cue --from bytes --to bytes < $(kind-proved) > $(kind-proved-cued)
 
 $(kind-proved-cued-b64): $(kind-proved)
-	@juvix dev nockma encode --cue --from bytes --to base64 < $(kind-proved) > $(kind-proved-cued-b64)
+	@$(juvix-cmd) dev nockma encode --cue --from bytes --to base64 < $(kind-proved) > $(kind-proved-cued-b64)
 
 $(filter-request): $(kind-proved-cued-b64)
 	jq -n --arg KIND $$(cat $(kind-proved-cued-b64)) \
@@ -147,13 +154,13 @@ $(filter-request): $(kind-proved-cued-b64)
 	> $(filter-request)
 
 $(get-message-nockma): $(anoma-build) $(get-message-juvix)
-	@juvix compile anoma $(get-message-juvix) -o $(get-message-nockma)
+	@$(juvix-cmd) compile anoma $(get-message-juvix) -o $(get-message-nockma)
 
 $(logic-nockma): $(anoma-build) $(logic-juvix)
-	juvix compile anoma $(logic-juvix) -o $(logic-nockma)
+	$(juvix-cmd) compile anoma $(logic-juvix) -o $(logic-nockma)
 
 $(logic-proved): $(logic-nockma) $(config)
-	juvix dev anoma -c $(config) prove $(logic-nockma) -o $(logic-proved)
+	$(juvix-cmd) dev anoma -c $(config) prove $(logic-nockma) -o $(logic-proved)
 
 .PHONY: $(unspent-resources)
 $(unspent-resources): $(anoma-build) $(host) $(port) $(filter-request)

--- a/Kudos/makefile
+++ b/Kudos/makefile
@@ -8,6 +8,12 @@ quantity ?= $(error set the quantity variable to a number)
 root = $(shell pwd)
 merge-id ?= 0
 
+ifneq ($(XDG_CONFIG_HOME),)
+    juvix-cmd = XDG_CONFIG_HOME=$(XDG_CONFIG_HOME) juvix
+else
+    juvix-cmd = juvix
+endif
+
 # block-height is used by has-transaction-after-height
 block-height ?= $(error set the block-height variable)
 
@@ -119,7 +125,7 @@ anoma-stop:
 ifdef ANOMA_DEBUG
 	@echo "ANOMA_DEBUG is incompatible with anoma-stop" && false
 else
-	juvix dev anoma stop
+	$(juvix-cmd) dev anoma stop
 endif
 
 .PHONY: anoma-start
@@ -129,7 +135,7 @@ ifdef ANOMA_DEBUG
 	cd $(ANOMA_PATH) && \
 		mix run --no-halt $(root)/../start-config.exs
 else
-	juvix dev anoma start --force --anoma-dir $(ANOMA_PATH)
+	$(juvix-cmd) dev anoma start --force --anoma-dir $(ANOMA_PATH)
 endif
 
 .PHONY: get-balance-resources
@@ -142,15 +148,15 @@ get-balance: $(get-balance-proved-txt)
 
 .PHONY: kudos-initialize
 kudos-initialize: $(create-proved) $(config)
-	juvix dev anoma -c $(config) add-transaction $(create-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(create-proved)
 
 .PHONY: kudos-transfer
 kudos-transfer: $(transfer-proved) $(config)
-	juvix dev anoma -c $(config) add-transaction $(transfer-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(transfer-proved)
 
 .PHONY: kudos-merge
 kudos-merge: $(merge-proved) $(config)
-	juvix dev anoma -c $(config) add-transaction $(merge-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(merge-proved)
 
 .PHONY: get-unspent-resources
 get-unspent-resources: $(unspent-resources)
@@ -159,7 +165,7 @@ get-unspent-resources: $(unspent-resources)
 .PHONY: did-it-work
 did-it-work:
 	rm -f $(config)
-	juvix dev anoma start --anoma-dir $(ANOMA_PATH) -f
+	$(juvix-cmd) dev anoma start --anoma-dir $(ANOMA_PATH) -f
 	make kudos-initialize
 	watch -n 0.5 make get-unspent-resources
 
@@ -172,7 +178,7 @@ $(config): $(anoma-build)
 ifdef ANOMA_DEBUG
 	cp $(anoma-config) $(config)
 else
-	juvix dev anoma print-config > $(config)
+	$(juvix-cmd) dev anoma print-config > $(config)
 endif
 
 $(host): $(config)
@@ -219,17 +225,17 @@ $(has-transaction-after-height): $(anoma-build) $(host) $(port)
 
 $(logic-nockma): $(anoma-build) $(all-juvix)
 	juvix clean
-	juvix compile anoma $(logic-juvix) -o $(logic-nockma)
+	$(juvix-cmd) compile anoma $(logic-juvix) -o $(logic-nockma)
 
 $(logic-proved): $(logic-nockma) $(config)
-	juvix dev anoma -c $(config) prove $(logic-nockma) -o $(logic-proved)
+	$(juvix-cmd) dev anoma -c $(config) prove $(logic-nockma) -o $(logic-proved)
 
 $(create-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(create-juvix) -o $(create-nockma)
+	$(juvix-cmd) compile anoma $(create-juvix) -o $(create-nockma)
 
 $(transfer-nockma): $(anoma-build) $(all-juvix)
 	juvix clean
-	juvix compile anoma $(transfer-juvix) -o $(transfer-nockma)
+	$(juvix-cmd) compile anoma $(transfer-juvix) -o $(transfer-nockma)
 
 $(owner-public-key-base64): $(owner-public-key)
 	base64 < $(owner-public-key) | tr -d "\n\r" > $(owner-public-key-base64)
@@ -261,7 +267,7 @@ $(owner-balance-resources): $(anoma-build) $(host) $(port) $(owner-request)
 	> $@
 
 $(create-proved): $(create-nockma) $(config) $(random-32bytes) $(logic-proved) $(owner-signing-key) $(owner-public-key) $(owner-id-file)
-	juvix dev anoma -c $(config) prove $(create-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(create-nockma) \
 	-o $(create-proved) \
 	--arg 'bytearray:$(owner-signing-key)' \
 	--arg 'bytearray:$(owner-public-key)' \
@@ -271,7 +277,7 @@ $(create-proved): $(create-nockma) $(config) $(random-32bytes) $(logic-proved) $
 	--arg 'bytes-unjammed:$(owner-id-file)' \
 
 $(transfer-proved): $(transfer-nockma) $(config) $(random-32bytes) $(logic-proved) $(receiver-public-key) $(owner-first-resource) $(get-latest-root)
-	juvix dev anoma -c $(config) prove $(transfer-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(transfer-nockma) \
 	-o $(transfer-proved) \
 	--arg 'base64-unjammed:$(get-latest-root)' \
 	--arg 'bytes-unjammed:$(random-32bytes)' \
@@ -321,10 +327,10 @@ $(merge-public-key): $(person-public-key)-$(merge-id)
 	cp $< $@
 
 $(kudos-kind-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(kudos-kind-juvix) -o $(kudos-kind-nockma)
+	$(juvix-cmd) compile anoma $(kudos-kind-juvix) -o $(kudos-kind-nockma)
 
 $(merge-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(merge-juvix) -o $(merge-nockma)
+	$(juvix-cmd) compile anoma $(merge-juvix) -o $(merge-nockma)
 
 $(to-merge-public-key): $(person-public-key)-$(merge-id)
 	cp $< $@
@@ -334,14 +340,14 @@ $(to-merge-kudos-symbol):
 	echo $(merge-id) | tr -d '\n' > $@
 
 $(merge-kudos-kind-proved): $(kudos-kind-nockma) $(config) $(logic-proved) $(to-merge-public-key) $(to-merge-kudos-symbol)
-	juvix dev anoma -c $(config) prove $(kudos-kind-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(kudos-kind-nockma) \
 	--arg 'bytes:$(logic-proved)' \
 	--arg 'bytearray:$(to-merge-public-key)' \
 	--arg 'bytes-unjammed:$(to-merge-kudos-symbol)' \
 	-o $@
 
 $(to-merge-kind-cued-proved-base64): $(merge-kudos-kind-proved)
-	juvix dev nockma encode --cue --from bytes --to base64 < $< > $@
+	$(juvix-cmd) dev nockma encode --cue --from bytes --to base64 < $< > $@
 
 $(to-merge-resources-request): $(owner-public-key-base64) $(to-merge-kind-cued-proved-base64)
 	jq -n \
@@ -360,7 +366,7 @@ $(to-merge-resources): $(host) $(port) $(to-merge-resources-request)
 	> $@
 
 $(merge-proved): $(merge-nockma) $(random-32bytes) $(get-latest-root) $(logic-proved) $(owner-signing-key) $(owner-public-key) $(receiver-public-key) $(to-merge-resources)
-	juvix dev anoma -c $(config) prove $(merge-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(merge-nockma) \
 	--arg 'base64-unjammed:$(get-latest-root)' \
 	--arg 'bytes-unjammed:$(random-32bytes)' \
     --arg 'bytearray:$(owner-signing-key)' \
@@ -371,12 +377,12 @@ $(merge-proved): $(merge-nockma) $(random-32bytes) $(get-latest-root) $(logic-pr
 	-o $@ \
 
 $(get-balance-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(get-balance-juvix) -o $(get-balance-nockma)
+	$(juvix-cmd) compile anoma $(get-balance-juvix) -o $(get-balance-nockma)
 
 $(get-balance-proved): $(config) $(get-balance-nockma) $(owner-balance-resources)
-	juvix dev anoma -c $(config) prove $(get-balance-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(get-balance-nockma) \
 	--arg 'list:$(owner-balance-resources)' \
 	-o $@
 
 $(get-balance-proved-txt): $(get-balance-proved)
-	juvix dev nockma encode --cue --from bytes --to bytes < $< > $@
+	$(juvix-cmd) dev nockma encode --cue --from bytes --to bytes < $< > $@

--- a/Kudos/makefile-split
+++ b/Kudos/makefile-split
@@ -22,13 +22,13 @@ owner-to-split-resource = $(anoma-build-dir)/owner-to-split-resource
 
 .PHONY: kudos-split
 kudos-split: $(split-proved) $(config)
-	juvix dev anoma -c $(config) add-transaction $(split-proved)
+	$(juvix-cmd) dev anoma -c $(config) add-transaction $(split-proved)
 
 $(split-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(split-juvix) -o $(split-nockma)
+	$(juvix-cmd) compile anoma $(split-juvix) -o $(split-nockma)
 
 $(make-part-nockma): $(anoma-build) $(all-juvix)
-	juvix compile anoma $(make-part-juvix) -o $(make-part-nockma)
+	$(juvix-cmd) compile anoma $(make-part-juvix) -o $(make-part-nockma)
 
 $(owner-to-split-signing-key): $(addprefix $(person-signing-key)-, $(shell yq -r '.owner' < $(split-spec) | tr -d '\n'))
 	cp $< $@
@@ -43,14 +43,14 @@ $(owner-to-split-kudos-symbol): $(split-spec)
 	yq -r '.owner' < $(split-spec) | tr -d '\n' > $@
 
 $(owner-to-split-kudos-kind-proved): $(kudos-kind-nockma) $(config) $(logic-proved) $(owner-to-split-public-key) $(owner-to-split-kudos-symbol)
-	juvix dev anoma -c $(config) prove $(kudos-kind-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(kudos-kind-nockma) \
 	--arg 'bytes:$(logic-proved)' \
 	--arg 'bytearray:$(owner-to-split-public-key)' \
 	--arg 'bytes-unjammed:$(owner-to-split-kudos-symbol)' \
 	-o $@
 
 $(owner-to-split-kudos-kind-proved-cued-base64): $(owner-to-split-kudos-kind-proved)
-	juvix dev nockma encode --cue --from bytes --to base64 < $< > $@
+	$(juvix-cmd) dev nockma encode --cue --from bytes --to base64 < $< > $@
 
 $(owner-to-split-resource-request): $(owner-to-split-public-key-base64) $(owner-to-split-kudos-kind-proved-cued-base64)
 	jq -n \
@@ -71,19 +71,19 @@ $(split-quantity)-%: $(anoma-build) $(split-spec)
 	yq -r '.partition.$*' < $(split-spec) > $@
 
 $(make-named-part-bytes)-%: $(config) $(make-part-nockma) $(person-public-key)-% $(split-quantity)-%
-	juvix dev anoma -c $(config) prove $(make-part-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(make-part-nockma) \
 	--arg 'bytearray:$(person-public-key)-$*' \
 	--arg "nat:$$(cat $(split-quantity)-$*)" \
 	-o $@ \
 
 $(make-named-part-base64)-%: $(make-named-part-bytes)-%
-	juvix dev nockma encode --from bytes --to base64 < $< > $@
+	$(juvix-cmd) dev nockma encode --from bytes --to base64 < $< > $@
 
 $(partition): $(addprefix $(make-named-part-base64)-, $(shell yq -r '.partition | keys[]' < $(split-spec)))
 	paste -d '\n' $^ > $(partition)
 
 $(split-proved): $(config) $(split-nockma) $(random-32bytes) $(partition) $(get-latest-root) $(logic-proved) $(split-nockma) $(owner-to-split-signing-key) $(owner-to-split-public-key) $(owner-to-split-resource)
-	juvix dev anoma -c $(config) prove $(split-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(split-nockma) \
 	--arg 'base64-unjammed:$(get-latest-root)' \
 	--arg 'bytes-unjammed:$(random-32bytes)' \
     --arg 'bytearray:$(owner-to-split-signing-key)' \

--- a/Kudos/makefile-swap
+++ b/Kudos/makefile-swap
@@ -84,10 +84,10 @@ $(owned-resources): $(anoma-build) $(host) $(port) $(owner-request)
 
 $(nockma): $(anoma-build) $(all-juvix)
 	juvix clean
-	juvix compile anoma $(juvix-src) -o $(nockma)
+	$(juvix-cmd) compile anoma $(juvix-src) -o $(nockma)
 
 $(proved): $(config) $(nockma) $(random-32bytes) $(get-give-resource-proved) $(get-latest-root) $(logic-proved) $(owner-signing-key) $(owner-public-key) $(give-originator-symbol) $(give-originator-public-key) $(give-quantity) $(want-originator-symbol) $(want-originator-public-key) $(want-quantity)
-	juvix dev anoma -c $(config) prove $(nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(nockma) \
 	--arg 'base64-unjammed:$(get-latest-root)' \
 	--arg 'bytes-unjammed:$(random-32bytes)' \
     --arg 'bytearray:$(owner-signing-key)' \
@@ -125,10 +125,10 @@ list-intents: $(list-intents-request) $(host) $(port)
 	< $(list-intents-request) \
 
 $(get-give-resource-nockma): $(anoma-build) $(get-give-resource-juvix)
-	juvix compile anoma $(get-give-resource-juvix) -o $(get-give-resource-nockma)
+	$(juvix-cmd) compile anoma $(get-give-resource-juvix) -o $(get-give-resource-nockma)
 
 $(get-give-resource-proved): $(config) $(owned-resources) $(give-originator-symbol) $(give-quantity) $(get-give-resource-nockma)
-	juvix dev anoma -c $(config) prove $(get-give-resource-nockma) \
+	$(juvix-cmd) dev anoma -c $(config) prove $(get-give-resource-nockma) \
 	--arg 'bytes-unjammed:$(give-originator-symbol)' \
 	--arg "nat:$$(cat $(give-quantity))" \
 	--arg "list:$(owned-resources)" \

--- a/SimpleHelloWorld/makefile
+++ b/SimpleHelloWorld/makefile
@@ -4,6 +4,12 @@ base = SimpleHelloWorld
 get-message = GetMessage
 root = $(shell pwd)
 
+ifneq ($(XDG_CONFIG_HOME),)
+    juvix-cmd = XDG_CONFIG_HOME=$(XDG_CONFIG_HOME) juvix
+else
+    juvix-cmd = juvix
+endif
+
 anoma-build-dir = anoma-build
 anoma-build = $(anoma-build-dir)/.exists
 
@@ -41,7 +47,7 @@ ifdef ANOMA_DEBUG
 	cd $(ANOMA_PATH) && \
 		mix run --no-halt $(root)/../start-config.exs
 else
-	juvix dev anoma start --force --anoma-dir $(ANOMA_PATH)
+	$(juvix-cmd) dev anoma start --force --anoma-dir $(ANOMA_PATH)
 endif
 
 .PHONY: anoma-stop
@@ -49,7 +55,7 @@ anoma-stop:
 ifdef ANOMA_DEBUG
 	@echo "ANOMA_DEBUG is incompatible with anoma-stop" && false
 else
-	juvix dev anoma stop
+	$(juvix-cmd) dev anoma stop
 endif
 
 .PHONY: $(message-file)
@@ -61,12 +67,12 @@ $(config): $(anoma-build)
 ifdef ANOMA_DEBUG
 	cp $(ANOMA_PATH)/config.yaml $(config)
 else
-	@juvix dev anoma print-config > $(config)
+	@$(juvix-cmd) dev anoma print-config > $(config)
 endif
 
 .PHONY: add-transaction
 add-transaction: $(proved) $(config)
-	@juvix dev anoma -c $(config) add-transaction $(proved)
+	@$(juvix-cmd) dev anoma -c $(config) add-transaction $(proved)
 
 .PHONY: get-last-message
 get-last-message: $(last-message-txt)
@@ -75,17 +81,17 @@ get-last-message: $(last-message-txt)
 .PHONY: $(last-message-txt)
 $(last-message-txt): $(get-message-nockma) $(config) $(unspent-resources)
 	@tail -n 1 $(unspent-resources) > $(temp-file)
-	@juvix dev anoma -c $(config) prove $(get-message-nockma) -o $(get-message-proved) --arg 'base64:$(temp-file)'
-	@juvix dev nockma encode --cue --from bytes --to bytes < anoma-build/GetMessage.proved.nockma > $(last-message-txt)
+	@$(juvix-cmd) dev anoma -c $(config) prove $(get-message-nockma) -o $(get-message-proved) --arg 'base64:$(temp-file)'
+	@$(juvix-cmd) dev nockma encode --cue --from bytes --to bytes < anoma-build/GetMessage.proved.nockma > $(last-message-txt)
 
 $(nockma): $(juvix) $(anoma-build)
-	@juvix compile anoma $(juvix) -o $(nockma)
+	@$(juvix-cmd) compile anoma $(juvix) -o $(nockma)
 
 $(proved): $(nockma) $(config)
-	@juvix dev anoma -c $(config) prove $(nockma) -o $(proved)
+	@$(juvix-cmd) dev anoma -c $(config) prove $(nockma) -o $(proved)
 
 $(get-message-nockma): $(anoma-build) $(get-message-juvix)
-	@juvix compile anoma $(get-message-juvix) -o $(get-message-nockma)
+	@$(juvix-cmd) compile anoma $(get-message-juvix) -o $(get-message-nockma)
 
 .PHONY: $(unspent-resources)
 $(unspent-resources): $(anoma-build) $(host) $(port)

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+parallel --line-buffer --tag --joblog parallel-timings.log \
+  'TMPDIR=$(mktemp -d); trap "XDG_CONFIG_HOME=$TMPDIR juvix dev anoma stop || true; rm -rf $TMPDIR" EXIT; \
+   cd {1} && XDG_CONFIG_HOME=$TMPDIR ./all-tests.sh 2>&1 | tee all-tests.log' \
+  ::: HelloWorld/tests SimpleHelloWorld/tests Counters/Counter/Simple/tests Counters/Counter/Unique/tests Kudos/tests
+


### PR DESCRIPTION
You can now run the apps tests in parallel with `./run-tests.sh`.

This is now used in the CI to run the tests.

Tests are passed XDG_CONFIG_DIR parameter to a temporary directory to:
1. Avoid conflicts with global dependencies
2. Allow for a seprate instance of anoma / juvix to be started with each run