### PR TITLE
Remove workaround for Juvix crash

### DIFF
--- a/Kudos/makefile
+++ b/Kudos/makefile
@@ -224,7 +224,6 @@ $(has-transaction-after-height): $(anoma-build) $(host) $(port)
 	> $@
 
 $(logic-nockma): $(anoma-build) $(all-juvix)
-	juvix clean
 	$(juvix-cmd) compile anoma $(logic-juvix) -o $(logic-nockma)
 
 $(logic-proved): $(logic-nockma) $(config)
@@ -234,7 +233,6 @@ $(create-nockma): $(anoma-build) $(all-juvix)
 	$(juvix-cmd) compile anoma $(create-juvix) -o $(create-nockma)
 
 $(transfer-nockma): $(anoma-build) $(all-juvix)
-	juvix clean
 	$(juvix-cmd) compile anoma $(transfer-juvix) -o $(transfer-nockma)
 
 $(owner-public-key-base64): $(owner-public-key)

--- a/Kudos/makefile-swap
+++ b/Kudos/makefile-swap
@@ -83,7 +83,6 @@ $(owned-resources): $(anoma-build) $(host) $(port) $(owner-request)
 	> $@
 
 $(nockma): $(anoma-build) $(all-juvix)
-	juvix clean
 	$(juvix-cmd) compile anoma $(juvix-src) -o $(nockma)
 
 $(proved): $(config) $(nockma) $(random-32bytes) $(get-give-resource-proved) $(get-latest-root) $(logic-proved) $(owner-signing-key) $(owner-public-key) $(give-originator-symbol) $(give-originator-public-key) $(give-quantity) $(want-originator-symbol) $(want-originator-public-key) $(want-quantity)


### PR DESCRIPTION
The `juvix clean` workaround is not required after https://github.com/anoma/juvix/pull/3350