### PR TITLE
Fix Taking AppData with a List of AppData.Value

### DIFF
--- a/Kudos/Kudos/Layer.juvix
+++ b/Kudos/Kudos/Layer.juvix
@@ -98,11 +98,11 @@ module Kudos;
   module Instance;
     otherPublic (args : Logic.Args) : Kudos.PublicData :=
       let
-        m : Map RawTag AnomaAtom := AppData.toMap1 (Logic.Args.appData args);
-        selfTag : RawTag := RawTag.fromTag (Logic.Args.selfTag args);
-      in case Map.lookup selfTag m of
-           | nothing := failwith "Kudos public data missing from AppData"
-           | just r := builtinAnomaDecode (AnomaAtom.toNat r);
+        d : List AppData.Value := Logic.Args.appData args;
+      in case d of
+           | AppData.Value.mk atom _ :: _ :=
+             builtinAnomaDecode (AnomaAtom.toNat atom)
+           | nil := failwith "Kudos public data missing from AppData";
   end;
 
   module Resource;


### PR DESCRIPTION
Previously this code assumed it took all of AppData which is incorrect and causes kudos to fail to verify