### PR TITLE
Remove passthrough logic on Kudos

### DIFF
--- a/Kudos/Kudos/Create.juvix
+++ b/Kudos/Kudos/Create.juvix
@@ -10,7 +10,7 @@ import Anoma.Identity.Internal open;
 import Kudos.Extra open;
 import Kudos.Layer open;
 
-isValidLogic (args : Logic.Args) : Bool := true ||
+isValidLogic (args : Logic.Args) : Bool :=
   let
     self := Logic.Args.self args;
     selfTag : Tag := Logic.Args.selfTag args;

--- a/Kudos/Kudos/Layer.juvix
+++ b/Kudos/Kudos/Layer.juvix
@@ -98,11 +98,11 @@ module Kudos;
   module Instance;
     otherPublic (args : Logic.Args) : Kudos.PublicData :=
       let
-        m : Map RawTag AnomaAtom := AppData.toMap1 (Logic.Args.appData args);
-        selfTag : RawTag := RawTag.fromTag (Logic.Args.selfTag args);
-      in case Map.lookup selfTag m of
-           | nothing := failwith "Kudos public data missing from AppData"
-           | just r := builtinAnomaDecode (AnomaAtom.toNat r);
+        d : List AppData.Value := Logic.Args.appData args;
+      in case d of
+           | AppData.Value.mk atom _ :: _ :=
+             builtinAnomaDecode (AnomaAtom.toNat atom)
+           | nil := failwith "Kudos public data missing from AppData";
   end;
 
   module Resource;


### PR DESCRIPTION
Before it always passed, now it should pass properly without this, the
previously patches in this list are ncessary

TODO:: This PR needs to also include the base version bump or else it
will fail to typecheck see

https://github.com/anoma/anoma-applib/pull/97