### PR TITLE
Fix duplicate declarations and arithmetic bug in bits.js helpers

### DIFF
--- a/anoma-client/src/nock-js/bits.js
+++ b/anoma-client/src/nock-js/bits.js
@@ -120,10 +120,6 @@ function atomToWords(atom) {
   return bytesToWords(atomToBytes(atom));
 }
 
-function atomToWords(atom) {
-  return bytesToWords(atomToBytes(atom));
-}
-
 function wordsToAtom(words) {
   return bytesToAtom(wordsToBytes(words));
 }
@@ -139,7 +135,7 @@ function slaq(bloq, len) {
 function chop(met, fum, wid, tou, dst, src) {
   var buf = atomToWords(src),
       len = buf.length,
-      i, j, san, mek, baf, bat, hut, san,
+      i, j, san, mek, baf, bat, hut,
       wuf, wut, waf, raf, wat, rat, hop;
   
   if ( met < 5 ) {
@@ -187,7 +183,7 @@ function cut(a, b, c, d) {
     return zero;
   }
   if ( bi + ci > len ) {
-    ci = len - b;
+    ci = len - bi;
   }
   if ( 0 === bi && ci === len ) {
     return d;


### PR DESCRIPTION
## Summary
- **Removed** an accidental duplicate `atomToWords` declaration so the helper is defined only once.
- **Cleaned** the `chop` helper’s variable list by dropping a second `san` declaration.
- **Corrected** an arithmetic bug in `cut` that subtracted a noun instead of its integer value.

## Testing
```bash
node --check anoma-client/src/nock-js/bits.js